### PR TITLE
Support filtering messages by returning nil from Converter

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -75,6 +75,9 @@ func (h *SlackHandler) Enabled(_ context.Context, level slog.Level) bool {
 
 func (h *SlackHandler) Handle(ctx context.Context, record slog.Record) error {
 	message := h.option.Converter(h.option.AddSource, h.option.ReplaceAttr, h.attrs, h.groups, &record)
+	if message == nil { // Permit the converter to return nil to filter out messages
+		return nil
+	}
 
 	if h.option.Channel != "" {
 		message.Channel = h.option.Channel


### PR DESCRIPTION
I'm using slog-slack along with slog-multi. It would be useful for me if I could use the Converter to filter messages. Seems like this could be easily achieved by supporting `nil` returns from the Converter function. 

I believe this would currently crash, but I haven't tested it